### PR TITLE
Feature/add buildtime vs runtime docs

### DIFF
--- a/docs/BuildTimeVsRunTimeEnv.md
+++ b/docs/BuildTimeVsRunTimeEnv.md
@@ -2,7 +2,7 @@
 
 Deploying Elixir applications can be hard to figure out, with multiple strategies
 involving tools like `distillery`, `docker`, `edeliver` or `mix` to choose from.
-At Annkissam, we have adopted a simple approach to deploying elixir applications,
+At Annkissam, we have adopted a simple workflow to deploying elixir applications,
 which we would like to share with the community.
 
 This post digs deeper into `Akd` while explaining how we at Annkissam use `akd`
@@ -15,9 +15,9 @@ mostly on CentOS servers. We typically have a build server (also CentOS) on whic
 we run the `Distillery` release task and copy the built release to a final
 destination on which the app is started.
 
-There are several pain points which we have recognized which deploying
+There are several pain-points which we have recognized which deploying
 elixir applications as releases. In this post, we will talk about one of those
-pain points and how `Akd` provides a solution for it.
+pain-points and how `Akd` provides a solution for it.
 
 ## Build-time vs Run-time Environment variables
 
@@ -29,11 +29,11 @@ While building releases, we have access to the `Mix.Config` of the project. This
 allows us to access the environment variables during compile (build) time using
 `System.get_env/1`. However, once built the value of `System.get_env` cannot be
 changed in the configuration. There are several ways of overcoming this.
-`Distillery` provides `REPLACE_OS_VARS` config which loads from run-time,
-`load_from_system_env` approach in `Phoenix` works to load environments lazily
-at Runtime or a tool like [`conform`](https://github.com/bitwalker/conform).
-`Akd` provides a simple approach to this problem which works for most of our
-applications.
+`Distillery` provides `REPLACE_OS_VARS` config which loads from environments
+from the destination server, `load_from_system_env` approach in `Phoenix` loads
+environments lazily at runtime or a tool like
+[`conform`](https://github.com/bitwalker/conform).  `Akd` provides it's own
+simplified solution to this problem which works for most of our applications.
 
 ### Providing environments before builds
 
@@ -275,5 +275,5 @@ at deploy-time.
   the command: This is a more complex approach, but it loads the runtime
   environments at publish time without having to provide them at deploy-time.
 
-This was just an example of how `akd` provides solutions to some pain points with
-Elixir deployments at Annkissam.
+This was just an example of how `akd` provides solutions to some of the problems
+we had with Elixir deployments at Annkissam.

--- a/docs/BuildTimeVsRunTimeEnv.md
+++ b/docs/BuildTimeVsRunTimeEnv.md
@@ -1,0 +1,279 @@
+# Using Akd to solve Build-time vs Runtime Environment Problem
+
+Deploying Elixir applications can be hard to figure out, with multiple strategies
+involving tools like `distillery`, `docker`, `edeliver` or `mix` to choose from.
+At Annkissam, we have adopted a simple approach to deploying elixir applications,
+which we would like to share with the community.
+
+This post digs deeper into `Akd` while explaining how we at Annkissam use `akd`
+to simplify one of the popular elixir deployment problems.
+
+## Prelude
+
+At Annkissam, we use `akd` with `distillery` to deploy OTP releases. We run them
+mostly on CentOS servers. We typically have a build server (also CentOS) on which
+we run the `Distillery` release task and copy the built release to a final
+destination on which the app is started.
+
+There are several pain points which we have recognized which deploying
+elixir applications as releases. In this post, we will talk about one of those
+pain points and how `Akd` provides a solution for it.
+
+## Build-time vs Run-time Environment variables
+
+There isn't much difference between the run-time and build-time environment when
+running a Mix project in dev environment. However, while using releases, they are
+often one of the biggest hurdles we have to face.
+
+While building releases, we have access to the `Mix.Config` of the project. This
+allows us to access the environment variables during compile (build) time using
+`System.get_env/1`. However, once built the value of `System.get_env` cannot be
+changed in the configuration. There are several ways of overcoming this.
+`Distillery` provides `REPLACE_OS_VARS` config which loads from run-time,
+`load_from_system_env` approach in `Phoenix` works to load environments lazily
+at Runtime or a tool like [`conform`](https://github.com/bitwalker/conform).
+`Akd` provides a simple approach to this problem which works for most of our
+applications.
+
+### Providing environments before builds
+
+`Akd` allows us to specify environment variables to `Hook` calls. At Annkissam,
+we use this feature to provide `build` time environment variables which can be
+used to build a release.
+
+Once, you have generated an `akd` task, we can configure it to add environment
+variables. `Akd.Build.Distillery` accepts `cmd_envs` as a list of `Tuple`s:
+
+_For more information on how to generate an akd task, check
+[the documentation](https://hexdocs.pm/akd/Mix.Tasks.Akd.Gen.Task.html) or
+the [Walkthrough](https://www.annkissam.com/technology/elixir)_
+
+```elixir
+# in the deploy task
+
+pipeline :build do
+  hook Akd.Build.Distillery,
+    run_ensure: false,
+    cmd_env: [{"SOME_ENV", "some_value"}]
+end
+
+```
+
+Doing this builds the `distillery` release with an environment variable,
+`SOME_ENV` with value `"some_value"`.
+
+Similarly, we can pass run-time environments to the publish hook,
+`Akd.Publish.Distillery` call:
+
+```elixir
+# in the deploy task
+
+pipeline :publish do
+  hook Akd.Stop.Distillery, ignore_failure: true
+
+  hook Akd.Publish.Distillery, scp_options: "-o \"ForwardAgent yes\""
+
+  hook Akd.Start.Distillery,
+    cmd_env: [{"ECTO_DB_URL", "ecto://user:password@127.0.0.1/database"}]
+end
+```
+
+This approach is particularly useful as it doesn't export environment variables,
+but just calls the command with those environment. This means our deploys are
+not changing the environment of the `publish` server. This allows us to deploy
+and run multiple instances of the same app on the same server or apps that
+happen to share the same environment variable names, without interfering with
+one another.
+
+However, there's a small problem with this approach: We need to know the
+runtime environments at deploy time (while calling `$ mix akd.deploy`).
+
+For apps where we don't have access to the runtime environments at deploy-time,
+we use a different approach.
+
+### The Env Command
+
+Another way to pass runtime environments is to put them in a file inside a
+unique folder in the destination server (We use
+`<path-to-the-release>/support/environment`). This file contains all the
+environment variables needed to run a built release.
+
+For example:
+
+```bash
+# in support/environment
+
+HOST="localhost"
+ECTO_DB_URL="ecto://user:password@127.0.0.1/database"
+```
+
+Now, we just have to `cat` the contents of this file and prepend them whenever
+we want to run the `start` command of a `distillery` release.
+
+A way to automate that is by writing a Custom Distillery Command, `env`.
+
+`Akd.Init.Distillery` hook call accepts a `template` option, which takes a path
+to a distillery config's template file. This allows us to customize the use
+of `distillery` with `akd`.
+
+We can write a custom template, which specifies a custom command `env`:
+
+```elixir
+# in config.ex.exs
+
+~w(rel plugins *.exs)
+|> Path.join()
+|> Path.wildcard()
+|> Enum.map(&Code.eval_file(&1))
+
+use Mix.Releases.Config,
+    default_release: :default,
+    default_environment: Mix.env()
+<% end %>
+
+environment :dev do
+  set dev_mode: true
+  set include_erts: false
+  set cookie: <%= inspect(get_cookie.()) %>
+end
+
+environment :prod do
+  set include_erts: true
+  set include_src: false
+  set cookie: <%= inspect(get_cookie.()) %>
+end
+
+environment :staging do
+  set include_erts: true
+  set include_src: false
+  set vm_args: "deployer/priv/vm.args.eex"
+  set cookie: <%= inspect(get_cookie.()) %>
+end
+
+<%= for release <- releases do %><%= if Keyword.get(release, :is_umbrella) do %>
+release :<%= Keyword.get(release, :release_name) %> do
+  set version: Mix.Project.config[:version]
+  set applications: [
+    :runtime_tools,
+<%= Enum.map(Keyword.get(release, :release_applications), fn {app, start_type} ->
+    "    #{app}: :#{start_type}"
+    end) |> Enum.join(",\n") %>
+  ]
+  set commands: [
+    env: "commands/env.sh", # Add a custom command named env.
+  ]
+end<% else %>
+release :<%= Keyword.get(release, :release_name) %> do
+  set version: current_version(:<%= Keyword.get(release, :release_name)%>)
+  set applications: [
+    :runtime_tools
+  ]
+end<% end %>
+<% end %>
+```
+
+Currently, as of `distillery 1.5`, this is the only way of specifying a custom
+command before `init`. For more information on custom command, check out
+[this post](https://hexdocs.pm/distillery/custom-commands.html#content).
+
+Now we can create a file `commands/env.sh` which has the following content:
+
+```bash
+# in commands/env.sh
+
+env $(cat ./support/environment | xargs) bin/release_name $1
+```
+
+This allows us to call `bin/release_name env <command>`. All this command does
+is get environments from `support/environment` file and call it with the
+original command `<command>`.
+
+Once published, it can be used as: `$ bin/release_name env start`
+
+Now, we can generate a custom hook that use the `env` command to start the
+released application.
+
+To generate a custom hook run: `$ mix akd.gen.hook Deployer.Hooks.EnvStart`.
+
+_To learn more about custom hook generator, check out
+[this page](https://hexdocs.pm/akd/Mix.Tasks.Akd.Gen.Hook.html#content)_
+
+We can replace the generated file's contents with the following:
+
+```elixir
+# lib/hooks/env_start.ex
+
+defmodule Deployer.Hooks.EnvStart do
+  @moduledoc """
+  Custom Start hook for Annkissam's workflow of loading the env variables
+  only for the start command.
+  """
+
+  use Akd.Hook
+
+  @default_opts [run_ensure: true, ignore_failure: false]
+
+  @doc false
+  @spec get_hooks(Akd.Deployment.t, Keyword.t) :: list(Akd.Hook.t)
+  def get_hooks(deployment, opts \\ []) do
+    opts = uniq_merge(opts, @default_opts)
+    [start_hook(deployment, opts)]
+  end
+
+  # This function takes a deployment and options and returns an Akd.Hook.t
+  # struct using FormHook DSL
+  defp start_hook(deployment, opts) do
+    destination = Akd.DestinationResolver.resolve(:publish, deployment)
+    cmd_env = Keyword.get(opts, :cmd_env, [])
+
+    form_hook opts do
+      main "bin/#{deployment.name} env start", destination,
+        cmd_env: cmd_env
+    end
+  end
+
+  # This function takes two keyword lists and merges them keeping the keys
+  # unique. If there are multiple values for a key, it takes the value from
+  # the first value of keyword1 corresponding to that key.
+  defp uniq_merge(keyword1, keyword2) do
+    keyword2
+    |> Keyword.merge(keyword1)
+    |> Keyword.new()
+  end
+end
+```
+
+This hook allows us to call the `start` command of a `distillery` release with
+loaded runtime environments.
+
+Now we can replace `Akd.Start.Distillery` with `Deployer.Hooks.EnvStart` in
+out `:publish` pipeline of the `akd` task:
+
+```elixir
+# in the deploy task
+
+pipeline :publish do
+  hook Akd.Stop.Distillery, ignore_failure: true
+
+  hook Akd.Publish.Distillery, scp_options: "-o \"ForwardAgent yes\""
+
+  hook Deployer.Hooks.EnvStart
+end
+```
+
+Now, our deployments can use runtime variables without us having to specify them
+at deploy-time.
+
+## Conclusion
+
+`Akd` provides two ways of providing run-time configuration to a release:
+
+* By adding `cmd_envs` to the start hook: This is a simpler approach, but needs
+  us to specify runtime environments at deploy-time.
+
+* By creating a custom `distillery` command, and a custom `akd` hook which calls
+  the command: This is a more complex approach, but it loads the runtime
+  environments at publish time without having to provide them at deploy-time.
+
+This was just an example of how `akd` provides solutions to some pain points with
+Elixir deployments at Annkissam.

--- a/docs/BuildTimeVsRunTimeEnv.md
+++ b/docs/BuildTimeVsRunTimeEnv.md
@@ -1,4 +1,4 @@
-# Using Akd to solve Build-time vs Run-time Environment problem
+# Using Akd to Solve Build-time vs Run-time Environment problem
 
 Deploying Elixir applications can be hard to figure out, with multiple strategies
 involving tools like `distillery`, `docker`, `edeliver` or `mix` to choose from.

--- a/docs/DeploymentStrategies.md
+++ b/docs/DeploymentStrategies.md
@@ -42,8 +42,12 @@ as the production server (same OS, similar packages etc)
 
 ### Using Akd with Distillery
 
+- __TODO__
+
 
 ## Local Distillery build w/ ERTS + Deliver to production
+
+- __TODO__
 
 
 ## Asdf on production
@@ -75,6 +79,4 @@ production server.
 
 ### How akd does it
 
-
-
-
+- __TODO__

--- a/mix.exs
+++ b/mix.exs
@@ -62,11 +62,14 @@ defmodule Akd.Mixfile do
   def docs do
     [
       main: "Akd",
-      extras: ["docs/Nomenclature.md",
-               "docs/DeploymentStrategies.md",
-               "docs/Walkthrough.md",
-               "docs/CustomHooks.md",
-               "docs/UsingGenerators.md"],
+      extras: [
+        "docs/BuildTimeVsRunTimeEnv.md",
+        "docs/CustomHooks.md",
+        "docs/DeploymentStrategies.md",
+        "docs/Nomenclature.md",
+        "docs/UsingGenerators.md"
+        "docs/Walkthrough.md",
+      ],
       source_url: @url,
       source_ref: "v#{@version}"
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -67,8 +67,8 @@ defmodule Akd.Mixfile do
         "docs/CustomHooks.md",
         "docs/DeploymentStrategies.md",
         "docs/Nomenclature.md",
-        "docs/UsingGenerators.md"
-        "docs/Walkthrough.md",
+        "docs/UsingGenerators.md",
+        "docs/Walkthrough.md"
       ],
       source_url: @url,
       source_ref: "v#{@version}"

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule Akd.Mixfile do
 
   defp description do
     """
-    An configurable (but easy to set up) Elixir Deployment Automation library.
+    A configurable (but easy to set up) Elixir Deployment Automation library.
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule Akd.Mixfile do
 
   defp description do
     """
-    A configurable (but easy to set up) Elixir Deployment Automation library.
+    A configurable (but easy to set up) Elixir deployment automation library.
     """
   end
 


### PR DESCRIPTION
This post covers:

- Using `cmd_envs` with `Akd.Hook`
- Generating a custom `Akd.Hook`.
- Annkissam's solutions to build-time vs runtime environment variables.
- Addresses #47 