### PR TITLE
install hex and rebar on init

### DIFF
--- a/lib/akd/base/init/distillery.ex
+++ b/lib/akd/base/init/distillery.ex
@@ -95,8 +95,8 @@ defmodule Akd.Init.Distillery do
       fn(cmd, acc) -> acc <> " " <> cmd end)
   end
 
-  # These commands are to be ran before calling release init
-  defp setup(), do: "mix deps.get \n mix compile"
+  # These commands are to be run before calling release init
+  defp setup(), do: "mix local.rebar --force \n mix local.hex --force \n mix deps.get \n mix compile"
 
   # This function returns sub-command associated with template switch
   defp template_cmd(nil), do: ""


### PR DESCRIPTION
@aditya7iyengar Is there a reason we shouldn't run this? I think we could argue about permissions (and if this command _should_ do this. So maybe it's an option?